### PR TITLE
chore: upgrade bower 

### DIFF
--- a/guide/step-1.md
+++ b/guide/step-1.md
@@ -1,6 +1,6 @@
 ## Step 1: Adding Angular
 
-[Comparison from step-0 to step-1](/../../../compare/step-0...step-1)
+[Comparison from step-0 to step-1](/../../compare/step-0...step-1)
 
 *You can checkout the repo at tag [`step-1`](/../../../tree/step-1) to see the end result of what is detailed here*
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/jasmine": "2.5.52",
     "@types/jasminewd2": "2.0.3",
     "@types/node": "6.0.78",
-    "bower": "1.8.0",
+    "bower": "1.8.8",
     "codelyzer": "3.0.1",
     "grunt": "1.0.1",
     "grunt-angular-file-loader": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,9 +720,10 @@ bower-config@^1.3.0:
     osenv "^0.1.3"
     untildify "^2.1.0"
 
-bower@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.0.tgz#55dbebef0ad9155382d9e9d3e497c1372345b44a"
+bower@1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.8.tgz#82544be34a33aeae7efb8bdf9905247b2cffa985"
+  integrity sha512-1SrJnXnkP9soITHptSO+ahx3QKp3cVzn8poI6ujqc5SeOkg5iqM1pK9H+DSc2OQ8SnO0jC/NG4Ur/UIwy7574A==
 
 brace-expansion@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Updating with some minor changes from original repo. 

* Upgrade bower to 1.8.8 to use bower.io repo
* Update readme to fix a link